### PR TITLE
catch error raised inside settings code

### DIFF
--- a/configurations/importer.py
+++ b/configurations/importer.py
@@ -161,6 +161,6 @@ class SettingsLoader(object):
                     raise ImproperlyConfigured(
                         "Couldn't execute callable '%s' in '%s.%s': %s" %
                         (value, mod.__name__, self.name, err))
-                setattr(mod, name, value)
+            setattr(mod, name, value)
         setattr(mod, 'CONFIGURATION', '%s.%s' % (fullname, self.name))
         return mod


### PR DESCRIPTION
I just spent hours trying to debug a configuration settings.

One property raised an exception because of bad permissions.

This was silently ignored.

With this it's far easier to troubleshoot issues inside settings themself
