### PR TITLE
Errors when calling with additional manage.py command

### DIFF
--- a/configurations/importer.py
+++ b/configurations/importer.py
@@ -1,3 +1,4 @@
+import argparse
 import imp
 import os
 import sys
@@ -84,10 +85,13 @@ class SettingsImporter(object):
     error_msg = "Settings cannot be imported, environment variable %s is undefined."
 
     def __init__(self):
-        parser = OptionParser(option_list=configuration_options, add_help_option=False)
-        options, args = parser.parse_args(sys.argv[2:])
-        if options.configuration:
-            os.environ[self.class_varname] = options.configuration
+        parser = argparse.ArgumentParser(add_help=False)
+        for option in configuration_options:
+            parser.add_argument(option.get_opt_string())
+        known_options, unknown_options = parser.parse_known_args()
+
+        if known_options.configuration:
+            os.environ[self.class_varname] = known_options.configuration
         self.validate()
 
     def __repr__(self):


### PR DESCRIPTION
Hi there.  Seems as though there was an issue with passing additional commands to manage.py when using the latest version of django-configurations, as per issue #21.

I'm not familiar with optparse or argparse, but where the configuration parameter is parsed OptionParser is used, but this baulks at unknown values (like those extra ones passed to manage.py).  I couldn't see an easy way to get a list of all allowed values, so seemed easiest to switch to using argparse for just this parsing task.

Not sure if this is how you'd want to implement long term, but it's a fix at least for now for anyone stuck.  Thanks for another handy Django app. :)
