### PR TITLE
Fix check_options of ConfigurationImporter

### DIFF
--- a/configurations/importer.py
+++ b/configurations/importer.py
@@ -95,9 +95,9 @@ class ConfigurationImporter(object):
 
     def __init__(self, check_options=False):
         self.argv = sys.argv[:]
-        self.validate()
         if check_options:
             self.check_options()
+        self.validate()
 
     def __repr__(self):
         return "<ConfigurationImporter for '{0}.{1}'>".format(self.module,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 from django.conf import global_settings
 from django.test import TestCase
@@ -78,3 +79,12 @@ class MainTests(TestCase):
         self.assertEqual(importer.module,
                          'tests.settings.inheritance')
         self.assertEqual(importer.name, 'Inheritance')
+
+    @patch.object(sys, 'argv', ['manage.py', 'test',
+                  '--settings=tests.settings.main', '--configuration=Test'])
+    def test_configuration_option(self):
+        importer = ConfigurationImporter(check_options=True)
+        self.assertEqual(importer.module, 'tests.settings.main')
+        self.assertEqual(importer.name, 'Test')
+        self.assertEqual(repr(importer),
+                         "<ConfigurationImporter for 'tests.settings.main.Test'>")


### PR DESCRIPTION
`--configuration` cmd line option did not work before without also setting configuration env variable, due to too early validation.
