### PR TITLE
test_cache_url_value fix

### DIFF
--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -282,7 +282,7 @@ class ValueTests(TestCase):
             'default': {
                 'BACKEND': 'redis_cache.cache.RedisCache',
                 'KEY_PREFIX': '',
-                'LOCATION': 'user@host:port:1'
+                'LOCATION': 'host:port:1'
             }
         }
         cache_url = 'redis://user@host:port/1'


### PR DESCRIPTION
Fixed test's expected settings since django-cache-url strips username out of connection string.
