### PR TITLE
Correct documentation about mixin usage

### DIFF
--- a/docs/patterns.rst
+++ b/docs/patterns.rst
@@ -71,7 +71,7 @@ a ``Configuration`` class::
 
     from configurations import Configuration
 
-    class Prod(Configuration, FullPageCaching):
+    class Prod(FullPageCaching, Configuration):
         DEBUG = False
         # ...
 


### PR DESCRIPTION
`Configuration` class needs to be last in the inheritance list, otherwise it's not possible to override Django's default settings. Tests are already correct, just the documentation is wrong.
