### PR TITLE
Fix optparse fallback logic in Django 1.8+

### DIFF
--- a/configurations/importer.py
+++ b/configurations/importer.py
@@ -37,9 +37,10 @@ def install(check_options=False):
                 if isinstance(parser, OptionParser):
                     # in case the option_list is set the create_parser
                     # will actually return a OptionParser for backward
-                    # compatibility. It uses BaseCommand.use_argparse
-                    # to decide that, which checks for the option_list list
-                    base.BaseCommand.option_list += configuration_options
+                    # compatibility. In that case we should tack our
+                    # options on to the end of the parser on the way out.
+                    for option in configuration_options:
+                        parser.add_option(option)
                 else:
                     # probably argparse, let's not import argparse though
                     parser.add_argument(CONFIGURATION_ARGUMENT,

--- a/tests/management/commands/old_optparse_command.py
+++ b/tests/management/commands/old_optparse_command.py
@@ -1,0 +1,16 @@
+from optparse import make_option
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+
+    # Used by a specific test to see how unupgraded
+    # management commands play with configurations.
+    # See the test code for more details.
+
+    option_list = BaseCommand.option_list + (
+        make_option('--arg1', action='store_true'),
+    )
+
+    def handle(self, *args, **options):
+        pass

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,4 +6,3 @@ dj-email-url
 dj-search-url
 django-cache-url>=1.0.0
 six
-unittest2

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,3 +6,4 @@ dj-email-url
 dj-search-url
 django-cache-url>=1.0.0
 six
+unittest2

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,12 +1,16 @@
 import os
 import subprocess
 import sys
-import unittest2
 
 from django import VERSION as DJANGO_VERSION
 from django.conf import global_settings
 from django.test import TestCase
 from django.core.exceptions import ImproperlyConfigured
+
+if sys.version_info >= (2, 7):
+    from unittest import skipIf
+else:
+    from django.utils.unittest import skipIf
 
 from mock import patch
 
@@ -111,7 +115,7 @@ class MainTests(TestCase):
                                 stdout=subprocess.PIPE)
         self.assertIn('--configuration', proc.communicate()[0].decode('utf-8'))
 
-    @unittest2.skipIf(DJANGO_VERSION >= (1, 10), 'only applies to Django < 1.10')
+    @skipIf(DJANGO_VERSION >= (1, 10), 'only applies to Django < 1.10')
     def test_deprecated_option_list_command(self):
         """
         Verify that the configuration option is correctly added to any

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,9 @@
 import os
 import subprocess
 import sys
+import unittest2
 
+from django import VERSION as DJANGO_VERSION
 from django.conf import global_settings
 from django.test import TestCase
 from django.core.exceptions import ImproperlyConfigured
@@ -108,3 +110,20 @@ class MainTests(TestCase):
         proc = subprocess.Popen(['django-cadmin', 'runserver', '--help'],
                                 stdout=subprocess.PIPE)
         self.assertIn('--configuration', proc.communicate()[0].decode('utf-8'))
+
+    @unittest2.skipIf(DJANGO_VERSION >= (1, 10), 'only applies to Django < 1.10')
+    def test_deprecated_option_list_command(self):
+        """
+        Verify that the configuration option is correctly added to any
+        management commands which are still relying on option_list to
+        add their own custom arguments
+
+        Specific test for a pattern which was deprecated in Django 1.8
+        and which will become completely unsupported in Django 1.10.
+        https://docs.djangoproject.com/en/1.8/howto/custom-management-commands/#custom-commands-options
+        """
+        proc = subprocess.Popen(['django-cadmin', 'old_optparse_command', '--help'],
+                                stdout=subprocess.PIPE)
+        output = proc.communicate()[0].decode('utf-8')
+        self.assertIn('--configuration', output)
+        self.assertIn('--arg1', output)


### PR DESCRIPTION
**Disclaimer**: I have read the discussions in https://github.com/jezdez/django-configurations/issues/105#issuecomment-88895512 and https://github.com/jezdez/django-configurations/commit/0ff4c7612d28036449edd4b2cf3b58ca1eded0f2, and I understand the situation this package is in. I pondered long and hard as to whether I should even open this pr.

I completely get it; by the time I am done: root-causing this issue, learning how configurations works, learning what the Django guys were trying to do in 1.8, learning how to run tox, writing tests, and finally authoring this pr, I will have spent _many hours_ on these three lines of diff. Hours I could have spent on "real work". I'm just fortunate -- and love (and need) this package enough! -- that my current workload happens to be light enough, and I happen to have enough caffeine, to make it happen. I fully understand that it could take hours more of time that someone doesn't have to confidently sign off on it.

**tl;dr:** If there's no time to even read this pull req, let alone merge it, no hard feelings!

----

OK, so here's the deal:

Django switched from optparse to argparse in Django 1.8 for extending management commands. To ease deprecation, until Django 1.10, there's some fun shim logic in Django. It says, "If the command I'm running appends anything to its `option_list` (the old way), we'll still use optparse. Otherwise, we'll use argparse."

Note that, until Django 1.10, the old optparse behavior gets checked first. In other words, if `option_list` is manipulated _and_ `add_arguments` (the new way) is implemented, we still use optparse, and anything in `add_arguments` is ignored.

That's important for configurations, because it means that we can't just, for instance, add our `--configuration` option to `option_list` up front and deal with the problem when it really gets deprecated in Django 1.10. In order to correctly wrap management commands from arbitrary packages, which may or may not have shifted over to `add_arguments` yet, we have to _wait and see what the command does_ (and thus what parser we get back), and then play our hand.

https://github.com/jezdez/django-configurations/commit/6ce3740365d92c329c1e20036266cd090d57b7c4 made an attempt at doing this, but the `base.BaseCommand.option_list += configuration_options` causes two problems, actually:

1. It doesn't actually add the configuration option to the command we are running right now. We just got handed the parser, which already looked at `BaseCommand.option_list`. So this line only adds the option for any commands run _after_ this. This is the subject of the test in the second commit of this pr, which fails on Django 1.8 if run without the patch in the other commit.

2. We're touching `base.BaseCommand.option_list`, which is a class variable. If we now run another management command in the same Django instance (say, via `call_command`), we will add the `--configuration` option a second time. Do this enough times (three, exactly), and you'll get an `OptionConflictError`. I encountered this while using django-nose, which evidently runs some subcommands under its `test` command. This is the cause of #109, and pr #110 implements a slightly hacky but working fix, but doesn't fix problem 1 above.

The proposed patch fixes both issues by:
* maintaining the existing "wait and see" behavior that accommodates both mgmt commands which have and have not upgraded their argument extension
* handling the optparse fallback case by one-off adding our argument(s) to the parser in our wrapped routine, leaving the global `BaseCommand.option_list` untouched

P.S. - Using the three management commands below and then running `manage.py command1` on Django 1.8 is enough to minimally repro the `OptionConflictError` problem. It would not be difficult to write a test to validate this doesn't happen any longer, but seemed like overkill.

```python
# command1.py
class Command(BaseCommand):

    option_list = BaseCommand.option_list + (
        make_option('--arg1', action='store_true'),
    )

    def handle(self, *args, **options):
        call_command('command2')

# command2.py
class Command(BaseCommand):

    option_list = BaseCommand.option_list + (
        make_option('--arg2', action='store_true'),
    )

    def handle(self, *args, **options):
        call_command('command3')

# command3.py
class Command(BaseCommand):

    option_list = BaseCommand.option_list + (
        make_option('--arg3', action='store_true'),
    )

    def handle(self, *args, **options):
        print 'hi'
```