### PR TITLE
Travis/tox: use dj19 tarball, add master; remove unsupported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,26 +26,38 @@ env:
     - TOXENV=py27-dj17
     - TOXENV=py27-dj18
     - TOXENV=py27-dj19
+    - TOXENV=py27-djmaster
     - TOXENV=py32-dj15
     - TOXENV=py32-dj16
     - TOXENV=py32-dj17
     - TOXENV=py32-dj18
-    - TOXENV=py32-dj19
     - TOXENV=py33-dj15
     - TOXENV=py33-dj16
     - TOXENV=py33-dj17
     - TOXENV=py33-dj18
-    - TOXENV=py33-dj19
     - TOXENV=py34-dj15
     - TOXENV=py34-dj16
     - TOXENV=py34-dj17
     - TOXENV=py34-dj18
     - TOXENV=py34-dj19
+    - TOXENV=py34-djmaster
+    - TOXENV=py35-dj15
+    - TOXENV=py35-dj16
+    - TOXENV=py35-dj17
+    - TOXENV=py35-dj18
+    - TOXENV=py35-dj19
+    - TOXENV=py35-djmaster
     - TOXENV=pypy-dj15
     - TOXENV=pypy-dj16
     - TOXENV=pypy-dj17
     - TOXENV=pypy-dj18
     - TOXENV=pypy-dj19
+    - TOXENV=pypy-djmaster
+  allow_failures:
+    - TOXENV=py27-djmaster
+    - TOXENV=py34-djmaster
+    - TOXENV=py35-djmaster
+    - TOXENV=pypy-djmaster
 install:
   - pip wheel -r tests/requirements.txt
   - pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,9 @@ envlist =
     flake8-py27,
     flake8-py33,
     py{26,py}-dj{14,15,16},
-    py27-dj{14,15,16,17,18,19},
-    py{32,33,34,py}-dj{15,16,17,18,19}
+    py27-dj{14,15,16,17,18,19,master},
+    py{32,33,34,py}-dj{15,16,17,18}
+    py{34,py}-dj{19,master}
 
 [testenv]
 basepython =

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,8 @@ deps =
     dj16: https://github.com/django/django/archive/stable/1.6.x.tar.gz#egg=django
     dj17: https://github.com/django/django/archive/stable/1.7.x.tar.gz#egg=django
     dj18: https://github.com/django/django/archive/stable/1.8.x.tar.gz#egg=django
-    dj19: https://github.com/django/django/archive/master.tar.gz#egg=django
+    dj19: https://github.com/django/django/archive/stable/1.9.x.tar.gz#egg=django
+    djmaster: https://github.com/django/django/archive/master.tar.gz#egg=django
 
 commands =
     coverage run {envbindir}/django-cadmin test -v2 {posargs:tests}


### PR DESCRIPTION
 - Add `allow_failures` section for Django master on Travis.
 - Django 1.9 is only supported on Python 2.7 and 3.4+.