### PR TITLE
Travis: use master branch in build status image

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 django-configurations
 =====================
 
-.. image:: https://secure.travis-ci.org/jazzband/django-configurations.png
+.. image:: https://travis-ci.org/jazzband/django-configurations.svg?branch=master
    :alt: Build Status
    :target: https://travis-ci.org/jazzband/django-configurations
 


### PR DESCRIPTION
The URL is the one suggested by Travis CI itself.