### PR TITLE
specify we are developing a new version.

### DIFF
--- a/configurations/__init__.py
+++ b/configurations/__init__.py
@@ -2,7 +2,7 @@
 from .base import Settings, Configuration
 from .decorators import pristinemethod
 
-__version__ = '1.0'
+__version__ = '1.0.1.dev'
 __all__ = ['Configuration', 'pristinemethod', 'Settings']
 
 


### PR DESCRIPTION
Version pattern follows the recommendation described by pep440.
https://www.python.org/dev/peps/pep-0440/#development-release-separators