### PR TITLE
Handle example usage for Django 1.9

### DIFF
--- a/docs/patterns.rst
+++ b/docs/patterns.rst
@@ -54,7 +54,7 @@ setting other values, e.g.::
 
         @property
         def LANGUAGES(self):
-            return Configuration.LANGUAGES + (('tlh', 'Klingon'),)
+            return list(Configuration.LANGUAGES) + [('tlh', 'Klingon')]
 
 Configuration mixins
 --------------------


### PR DESCRIPTION
Django 1.9 makes the languages setting a list of tuples.