### PR TITLE
Add configurations.autosetup

### DIFF
--- a/configurations/autosetup.py
+++ b/configurations/autosetup.py
@@ -1,0 +1,4 @@
+"""A module to automatically import and call :func:`setup()`."""
+from . import setup
+
+setup()

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -125,8 +125,7 @@ probably just add the following to the **beginning** of your settings module:
 
 .. code-block:: python
 
-    import configurations
-    configurations.setup()
+    from configurations import autosetup
 
 That has the same effect as using the ``manage.py`` or ``wsgi.py`` utilities.
 This will also call ``django.setup()`` on Django >= 1.7.
@@ -155,8 +154,7 @@ Celery's documentation`_:
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'mysite.settings')
     os.environ.setdefault('DJANGO_CONFIGURATION', 'MySiteConfiguration')
 
-    import configurations
-    configurations.setup()
+    from configurations import autosetup
 
     app = Celery('mysite')
     app.config_from_object('django.conf:settings')


### PR DESCRIPTION
This will automatically import and call `setup()`.

It is useful to keep the boilerplate with using django-configurations to
a minimum, and also play nice with helpers like "isort" that would tear
the "import" and calling of "configurations.setup()" apart - which is
understandable.

The downside obviously is that importing this module _will_ have
side-effects, which is considered to be bad in general [1].

So this is open for discussion/feedback.
I could imagine doing the automatic call to `setup()` only when Django
is detected for example.

1: http://chrismorgan.info/blog/say-no-to-import-side-effects-in-python.html