### PR TITLE
Fixed RemovedInDjango19Warning

### DIFF
--- a/configurations/utils.py
+++ b/configurations/utils.py
@@ -4,9 +4,9 @@ import sys
 from django.core.exceptions import ImproperlyConfigured
 from django.utils import six
 try:
-    from django.utils.importlib import import_module
-except ImportError:
     from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
 
 
 def isuppercase(name):

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -357,6 +357,7 @@ class ValueTests(TestCase):
         with env(DATABASE_URL='sqlite://'):
             self.assertEqual(value.setup('DATABASE_URL'), {
                 'default': {
+                    'CONN_MAX_AGE': 0,
                     'ENGINE': 'django.db.backends.sqlite3',
                     'HOST': '',
                     'NAME': ':memory:',


### PR DESCRIPTION
It's better to try the new import method first because in Django<1.9 the
old method is still available and will raise a RemovedInDjango19Warning
that we could have avoided.