### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ object oriented programming patterns.
 
 Check out the `documentation`__ for more complete examples.
 
-.. __: http://django-configurations.readthedocs.org/en/latest/
+.. __: https://django-configurations.readthedocs.io/en/latest/
 
 
 Quickstart

--- a/configurations/base.py
+++ b/configurations/base.py
@@ -15,7 +15,7 @@ __all__ = ['Configuration']
 install_failure = ("django-configurations settings importer wasn't "
                    "correctly installed. Please use one of the starter "
                    "functions to install it as mentioned in the docs: "
-                   "http://django-configurations.readthedocs.org/")
+                   "https://django-configurations.readthedocs.io/")
 
 
 class ConfigurationBase(type):

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -192,7 +192,7 @@ It also works with django-extensions's shell_plus_ management command.
 
 .. _IPython: http://ipython.org/
 .. _`manage your IPython profile`: http://ipython.org/ipython-doc/dev/config/overview.html#configuration-file-location
-.. _shell_plus: http://django-extensions.readthedocs.org/en/latest/shell_plus.html
+.. _shell_plus: https://django-extensions.readthedocs.io/en/latest/shell_plus.html
 
 FastCGI
 -------

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def find_version(*parts):
 setup(
     name="django-configurations",
     version=find_version("configurations", "__init__.py"),
-    url='http://django-configurations.readthedocs.org/',
+    url='https://django-configurations.readthedocs.io/',
     license='BSD',
     description="A helper for organizing Django settings.",
     long_description=read('README.rst'),


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.