### PR TITLE
Add `EMAIL_USE_SSL` to tests

### DIFF
--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -392,6 +392,7 @@ class ValueTests(TestCase):
                 'EMAIL_HOST_PASSWORD': 'password',
                 'EMAIL_HOST_USER': 'user@domain.com',
                 'EMAIL_PORT': 587,
+                'EMAIL_USE_SSL': False,
                 'EMAIL_USE_TLS': True})
         with env(EMAIL_URL='console://'):
             self.assertEqual(value.setup('EMAIL_URL'), {
@@ -401,6 +402,7 @@ class ValueTests(TestCase):
                 'EMAIL_HOST_PASSWORD': None,
                 'EMAIL_HOST_USER': None,
                 'EMAIL_PORT': None,
+                'EMAIL_USE_SSL': False,
                 'EMAIL_USE_TLS': False})
         with env(EMAIL_URL='smtps://user@domain.com:password@smtp.example.com:wrong'):
             self.assertRaises(ValueError, value.setup, 'TEST')
@@ -481,6 +483,7 @@ class ValueTests(TestCase):
                 'EMAIL_HOST_PASSWORD': 'password',
                 'EMAIL_HOST_USER': 'user@domain.com',
                 'EMAIL_PORT': 587,
+                'EMAIL_USE_SSL': False,
                 'EMAIL_USE_TLS': True
             })
             self.assertEqual(Target.EMAIL_BACKEND, 'django.core.mail.backends.smtp.EmailBackend')


### PR DESCRIPTION
 `dj-email-url` added support for `EMAIL_USE_SSL` in its latest version.