### PR TITLE
Fix truthy and falsey of values

### DIFF
--- a/configurations/values.py
+++ b/configurations/values.py
@@ -80,6 +80,12 @@ class Value(object):
     def __eq__(self, other):
         return self.value == other
 
+    def __bool__(self):
+        return bool(self.value)
+
+    # Compatibility with python 2
+    __nonzero__ = __bool__
+
     def full_environ_name(self, name):
         if self.environ_name:
             environ_name = self.environ_name

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -58,6 +58,14 @@ class ValueTests(TestCase):
 
             self.assertEqual(repr(value), repr('override'))
 
+    def test_value_truthy(self):
+        value = Value('default')
+        self.assertTrue(bool(value))
+
+    def test_value_falsey(self):
+        value = Value()
+        self.assertFalse(bool(value))
+
     @patch.dict(os.environ, clear=True, DJANGO_TEST='override')
     def test_env_var(self):
         value = Value('default')
@@ -99,7 +107,7 @@ class ValueTests(TestCase):
         value = BooleanValue(False)
         for truthy in value.true_values:
             with env(DJANGO_TEST=truthy):
-                self.assertTrue(value.setup('TEST'))
+                self.assertTrue(bool(value.setup('TEST')))
 
     def test_boolean_values_faulty(self):
         self.assertRaises(ValueError, BooleanValue, 'false')
@@ -108,7 +116,7 @@ class ValueTests(TestCase):
         value = BooleanValue(True)
         for falsy in value.false_values:
             with env(DJANGO_TEST=falsy):
-                self.assertFalse(value.setup('TEST'))
+                self.assertFalse(bool(value.setup('TEST')))
 
     def test_boolean_values_nonboolean(self):
         value = BooleanValue(True)


### PR DESCRIPTION
I noticed that truthy and falsey of Value class wasn't the expected. An example extracted directly from python console:

```
In [1]: from configurations.values import BooleanValue

In [2]: test = BooleanValue(False)

In [3]: test
Out[3]: False

In [4]: bool(test)
Out[4]: True
```

That is because `__bool__` method (`__nonzero__` for python 2) isn't implemented so is acting with default behavior, that is a `bool(self)`. In this case, the truthy or falsey value depends on value property of this class.

This is the behavior after change:

```
In [1]: from configurations.values import BooleanValue

In [2]: test = BooleanValue(False)

In [3]: test
Out[3]: False

In [4]: bool(test)
Out[4]: False
```