### PR TITLE
Drop unmaintained version of  django and python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 htmlcov/
 *.pyc
 dist/
+tests/docs/_build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,69 @@
 language: python
-python: 3.5
 sudo: false
 cache: pip
-env:
-  - TOXENV=flake8-py27
-  - TOXENV=flake8-py35
-  - TOXENV=readme-py27
-  - TOXENV=py27-dj18
-  - TOXENV=py27-dj19
-  - TOXENV=py27-djmaster
-  - TOXENV=py34-dj18
-  - TOXENV=py34-dj19
-  - TOXENV=py34-djmaster
-  - TOXENV=py35-dj18
-  - TOXENV=py35-dj19
-  - TOXENV=py35-djmaster
 matrix:
-  allow_failures:
-    - env: TOXENV=py27-djmaster
-    - env: TOXENV=py34-djmaster
-    - env: TOXENV=py35-djmaster
-    - env: TOXENV=pypy-djmaster
   include:
+    - env: TOXENV=flake8-py27
+      python: 2.7
+    - env: TOXENV=flake8-py36
+      python: 3.6
+    - env: TOXENV=readme-py27
+      python: 2.7
+    - env: TOXENV=py27-dj18
+      python: 2.7
+    - env: TOXENV=py27-dj110
+      python: 2.7
+    - env: TOXENV=py27-dj111
+      python: 2.7
+    - env: TOXENV=py34-dj18
+      python: 3.4
+    - env: TOXENV=py34-dj110
+      python: 3.4
+    - env: TOXENV=py34-dj111
+      python: 3.4
+    - env: TOXENV=py35-dj18
+      python: 3.5
+    - env: TOXENV=py35-dj110
+      python: 3.5
+    - env: TOXENV=py35-dj111
+      python: 3.5
+    - env: TOXENV=py36-dj18
+      python: 3.6
+    - env: TOXENV=py36-dj110
+      python: 3.6
+    - env: TOXENV=py36-dj111
+      python: 3.6
     - env: TOXENV=pypy-dj18
       python: pypy
-    - env: TOXENV=pypy-dj19
+    - env: TOXENV=pypy-dj110
       python: pypy
+    - env: TOXENV=pypy-dj111
+      python: pypy
+    - env: TOXENV=py34-dj20
+      python: 3.4
+    - env: TOXENV=py34-djmaster
+      python: 3.4
+    - env: TOXENV=py35-dj20
+      python: 3.5
+    - env: TOXENV=py35-djmaster
+      python: 3.5
+    - env: TOXENV=py36-dj20
+      python: 3.6
+    - env: TOXENV=py36-djmaster
+      python: 3.6
+  allow_failures:
+    - env: TOXENV=py34-dj20
+      python: 3.4
+    - env: TOXENV=py35-dj20
+      python: 3.5
+    - env: TOXENV=py36-dj20
+      python: 3.6
+    - env: TOXENV=py34-djmaster
+      python: 3.4
+    - env: TOXENV=py35-djmaster
+      python: 3.5
+    - env: TOXENV=py36-djmaster
+      python: 3.6
 install:
   - pip install tox
 script: tox -v
@@ -44,4 +82,4 @@ deploy:
   on:
     tags: true
     repo: jazzband/django-configurations
-    condition: "$TOXENV = py27-dj19"
+    condition: "$TOXENV = py36-dj111"

--- a/configurations/__init__.py
+++ b/configurations/__init__.py
@@ -2,7 +2,7 @@
 from .base import Configuration
 from .decorators import pristinemethod
 
-__version__ = '2.0'
+__version__ = '2.1'
 __all__ = ['Configuration', 'pristinemethod']
 
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     author_email='jannis@leidel.info',
     packages=['configurations'],
     entry_points={
-	'console_scripts': [
+        'console_scripts': [
             'django-cadmin = configurations.management:execute_from_command_line',
         ],
     },
@@ -48,10 +48,11 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Utilities',
     ],
     zip_safe=False,

--- a/tests/settings/main.py
+++ b/tests/settings/main.py
@@ -7,7 +7,9 @@ from configurations.values import BooleanValue
 
 
 class Test(Configuration):
-    BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), os.pardir))
+    BASE_DIR = os.path.abspath(
+        os.path.join(os.path.dirname(
+            os.path.abspath(__file__)), os.pardir))
 
     ENV_LOADED = BooleanValue(False)
 
@@ -38,10 +40,11 @@ class Test(Configuration):
     if django.VERSION[:2] < (1, 6):
         TEST_RUNNER = 'discover_runner.DiscoverRunner'
 
-    def TEMPLATE_CONTEXT_PROCESSORS(self):
-        return tuple(Configuration.TEMPLATE_CONTEXT_PROCESSORS) + (
-            'tests.settings.base.test_callback',
-        )
+    @property
+    def ALLOWED_HOSTS(self):
+        allowed_hosts = super(Test, self).ALLOWED_HOSTS[:]
+        allowed_hosts.append('base')
+        return allowed_hosts
 
     ATTRIBUTE_SETTING = True
 
@@ -54,7 +57,7 @@ class Test(Configuration):
     def METHOD_SETTING(self):
         return 2
 
-    LAMBDA_SETTING = lambda self: 3
+    LAMBDA_SETTING = lambda self: 3  # noqa: E731
 
     PRISTINE_LAMBDA_SETTING = pristinemethod(lambda: 4)
 

--- a/tests/settings/mixin_inheritance.py
+++ b/tests/settings/mixin_inheritance.py
@@ -2,24 +2,25 @@ from configurations import Configuration
 
 
 class Mixin1(object):
-
     @property
-    def TEMPLATE_CONTEXT_PROCESSORS(self):
-        return tuple(super(Mixin1, self).TEMPLATE_CONTEXT_PROCESSORS) + (
-            'some_app.context_processors.processor1',)
+    def ALLOWED_HOSTS(self):
+        allowed_hosts = super(Mixin1, self).ALLOWED_HOSTS[:]
+        allowed_hosts.append('test1')
+        return allowed_hosts
 
 
 class Mixin2(object):
 
     @property
-    def TEMPLATE_CONTEXT_PROCESSORS(self):
-        return tuple(super(Mixin2, self).TEMPLATE_CONTEXT_PROCESSORS) + (
-            'some_app.context_processors.processor2',)
+    def ALLOWED_HOSTS(self):
+        allowed_hosts = super(Mixin2, self).ALLOWED_HOSTS[:]
+        allowed_hosts.append('test2')
+        return allowed_hosts
 
 
 class Inheritance(Mixin2, Mixin1, Configuration):
 
-    @property
-    def TEMPLATE_CONTEXT_PROCESSORS(self):
-        return tuple(super(Inheritance, self).TEMPLATE_CONTEXT_PROCESSORS) + (
-            'some_app.context_processors.processorbase',)
+    def ALLOWED_HOSTS(self):
+        allowed_hosts = super(Inheritance, self).ALLOWED_HOSTS[:]
+        allowed_hosts.append('test3')
+        return allowed_hosts

--- a/tests/settings/multiple_inheritance.py
+++ b/tests/settings/multiple_inheritance.py
@@ -1,8 +1,9 @@
-from .main import Test
+from .single_inheritance import Inheritance as BaseInheritance
 
 
-class Inheritance(Test):
+class Inheritance(BaseInheritance):
 
-    def TEMPLATE_CONTEXT_PROCESSORS(self):
-        return tuple(super(Inheritance, self).TEMPLATE_CONTEXT_PROCESSORS()) + (
-            'tests.settings.base.test_callback',)
+    def ALLOWED_HOSTS(self):
+        allowed_hosts = super(Inheritance, self).ALLOWED_HOSTS[:]
+        allowed_hosts.append('test-test')
+        return allowed_hosts

--- a/tests/settings/single_inheritance.py
+++ b/tests/settings/single_inheritance.py
@@ -3,6 +3,8 @@ from .base import Base
 
 class Inheritance(Base):
 
-    def TEMPLATE_CONTEXT_PROCESSORS(self):
-        return tuple(super(Inheritance, self).TEMPLATE_CONTEXT_PROCESSORS) + (
-            'tests.settings.base.test_callback',)
+    @property
+    def ALLOWED_HOSTS(self):
+        allowed_hosts = super(Inheritance, self).ALLOWED_HOSTS[:]
+        allowed_hosts.append('test')
+        return allowed_hosts

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -1,6 +1,5 @@
 import os
 
-from django.conf import global_settings
 from django.test import TestCase
 
 from mock import patch
@@ -13,30 +12,27 @@ class InheritanceTests(TestCase):
                 DJANGO_SETTINGS_MODULE='tests.settings.single_inheritance')
     def test_inherited(self):
         from tests.settings import single_inheritance
-        self.assertEqual(single_inheritance.TEMPLATE_CONTEXT_PROCESSORS,
-                         tuple(global_settings.TEMPLATE_CONTEXT_PROCESSORS) + (
-                                  'tests.settings.base.test_callback',
-                               ))
+        self.assertEqual(
+            single_inheritance.ALLOWED_HOSTS,
+            ['test']
+        )
 
     @patch.dict(os.environ, clear=True,
                 DJANGO_CONFIGURATION='Inheritance',
                 DJANGO_SETTINGS_MODULE='tests.settings.multiple_inheritance')
     def test_inherited2(self):
         from tests.settings import multiple_inheritance
-        self.assertEqual(multiple_inheritance.TEMPLATE_CONTEXT_PROCESSORS,
-                         tuple(global_settings.TEMPLATE_CONTEXT_PROCESSORS) + (
-                                  'tests.settings.base.test_callback',
-                                  'tests.settings.base.test_callback',
-                              ))
+        self.assertEqual(
+            multiple_inheritance.ALLOWED_HOSTS,
+            ['test', 'test-test']
+        )
 
     @patch.dict(os.environ, clear=True,
                 DJANGO_CONFIGURATION='Inheritance',
                 DJANGO_SETTINGS_MODULE='tests.settings.mixin_inheritance')
     def test_inherited3(self):
         from tests.settings import mixin_inheritance
-        self.assertEqual(mixin_inheritance.TEMPLATE_CONTEXT_PROCESSORS,
-                         tuple(global_settings.TEMPLATE_CONTEXT_PROCESSORS) + (
-                                   'some_app.context_processors.processor1',
-                                   'some_app.context_processors.processor2',
-                                   'some_app.context_processors.processorbase',
-                               ))
+        self.assertEqual(
+            mixin_inheritance.ALLOWED_HOSTS,
+            ['test1', 'test2', 'test3']
+        )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,7 +3,6 @@ import subprocess
 import sys
 
 from django import VERSION as DJANGO_VERSION
-from django.conf import global_settings
 from django.test import TestCase
 from django.core.exceptions import ImproperlyConfigured
 
@@ -29,10 +28,7 @@ class MainTests(TestCase):
         self.assertTrue(lambda: callable(main.PRISTINE_LAMBDA_SETTING))
         self.assertNotEqual(main.PRISTINE_FUNCTION_SETTING, 5)
         self.assertTrue(lambda: callable(main.PRISTINE_FUNCTION_SETTING))
-        self.assertEqual(main.TEMPLATE_CONTEXT_PROCESSORS,
-                         tuple(global_settings.TEMPLATE_CONTEXT_PROCESSORS) + (
-                                   'tests.settings.base.test_callback',
-                               ))
+        self.assertEqual(main.ALLOWED_HOSTS, ['base'])
         self.assertEqual(main.PRE_SETUP_TEST_SETTING, 6)
         self.assertRaises(AttributeError, lambda: main.POST_SETUP_TEST_SETTING)
         self.assertEqual(main.Test.POST_SETUP_TEST_SETTING, 7)
@@ -74,8 +70,9 @@ class MainTests(TestCase):
         importer = ConfigurationImporter()
         self.assertEqual(importer.module, 'tests.settings.main')
         self.assertEqual(importer.name, 'Test')
-        self.assertEqual(repr(importer),
-                         "<ConfigurationImporter for 'tests.settings.main.Test'>")
+        self.assertEqual(
+            repr(importer),
+            "<ConfigurationImporter for 'tests.settings.main.Test'>")
 
     @patch.dict(os.environ, clear=True,
                 DJANGO_SETTINGS_MODULE='tests.settings.inheritance',
@@ -123,8 +120,9 @@ class MainTests(TestCase):
         and which will become completely unsupported in Django 1.10.
         https://docs.djangoproject.com/en/1.8/howto/custom-management-commands/#custom-commands-options
         """
-        proc = subprocess.Popen(['django-cadmin', 'old_optparse_command', '--help'],
-                                stdout=subprocess.PIPE)
+        proc = subprocess.Popen(
+            ['django-cadmin', 'old_optparse_command', '--help'],
+            stdout=subprocess.PIPE)
         output = proc.communicate()[0].decode('utf-8')
         self.assertIn('--configuration', output)
         self.assertIn('--arg1', output)

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -18,5 +18,4 @@ class SphinxTests(TestCase):
             '.',
             '_build/html',
         ], cwd=self.docs_dir, stderr=subprocess.STDOUT)
-        self.assertIn(b'waiting for workers', output)
         self.assertIn(b'build succeeded.', output)

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -377,10 +377,12 @@ class ValueTests(TestCase):
     def test_database_url_additional_args(self):
 
         def mock_database_url_caster(self, url, engine=None):
-            return { 'URL': url, 'ENGINE': engine }
+            return {'URL': url, 'ENGINE': engine}
 
-        with patch('configurations.values.DatabaseURLValue.caster', mock_database_url_caster):
-            value = DatabaseURLValue(engine='django_mysqlpool.backends.mysqlpool')
+        with patch('configurations.values.DatabaseURLValue.caster',
+                   mock_database_url_caster):
+            value = DatabaseURLValue(
+                engine='django_mysqlpool.backends.mysqlpool')
             with env(DATABASE_URL='sqlite://'):
                 self.assertEqual(value.setup('DATABASE_URL'), {
                     'default': {
@@ -392,7 +394,7 @@ class ValueTests(TestCase):
     def test_email_url_value(self):
         value = EmailURLValue()
         self.assertEqual(value.default, {})
-        with env(EMAIL_URL='smtps://user@domain.com:password@smtp.example.com:587'):
+        with env(EMAIL_URL='smtps://user@domain.com:password@smtp.example.com:587'):  # noqa: E501
             self.assertEqual(value.setup('EMAIL_URL'), {
                 'EMAIL_BACKEND': 'django.core.mail.backends.smtp.EmailBackend',
                 'EMAIL_FILE_PATH': '',
@@ -404,7 +406,7 @@ class ValueTests(TestCase):
                 'EMAIL_USE_TLS': True})
         with env(EMAIL_URL='console://'):
             self.assertEqual(value.setup('EMAIL_URL'), {
-                'EMAIL_BACKEND': 'django.core.mail.backends.console.EmailBackend',
+                'EMAIL_BACKEND': 'django.core.mail.backends.console.EmailBackend',  # noqa: E501
                 'EMAIL_FILE_PATH': '',
                 'EMAIL_HOST': None,
                 'EMAIL_HOST_PASSWORD': None,
@@ -412,7 +414,7 @@ class ValueTests(TestCase):
                 'EMAIL_PORT': None,
                 'EMAIL_USE_SSL': False,
                 'EMAIL_USE_TLS': False})
-        with env(EMAIL_URL='smtps://user@domain.com:password@smtp.example.com:wrong'):
+        with env(EMAIL_URL='smtps://user@domain.com:password@smtp.example.com:wrong'):  # noqa: E501
             self.assertRaises(ValueError, value.setup, 'TEST')
 
     def test_cache_url_value(self):
@@ -436,8 +438,9 @@ class ValueTests(TestCase):
         with env(CACHE_URL='redis://user@host:port/1'):
             with self.assertRaises(ValueError) as cm:
                 value.setup('TEST')
-            self.assertEqual(cm.exception.args[0],
-                             "Cannot interpret cache URL value 'redis://user@host:port/1'")
+            self.assertEqual(
+                cm.exception.args[0],
+                "Cannot interpret cache URL value 'redis://user@host:port/1'")
 
     def test_search_url_value(self):
         value = SearchURLValue()
@@ -445,7 +448,7 @@ class ValueTests(TestCase):
         with env(SEARCH_URL='elasticsearch://127.0.0.1:9200/index'):
             self.assertEqual(value.setup('SEARCH_URL'), {
                 'default': {
-                    'ENGINE': 'haystack.backends.elasticsearch_backend.ElasticsearchSearchEngine',
+                    'ENGINE': 'haystack.backends.elasticsearch_backend.ElasticsearchSearchEngine',  # noqa: E501
                     'URL': 'http://127.0.0.1:9200',
                     'INDEX_NAME': 'index',
                 }})
@@ -482,7 +485,7 @@ class ValueTests(TestCase):
             pass
 
         value = EmailURLValue()
-        with env(EMAIL_URL='smtps://user@domain.com:password@smtp.example.com:587'):
+        with env(EMAIL_URL='smtps://user@domain.com:password@smtp.example.com:587'):  # noqa: E501
             setup_value(Target, 'EMAIL', value)
             self.assertEqual(Target.EMAIL, {
                 'EMAIL_BACKEND': 'django.core.mail.backends.smtp.EmailBackend',
@@ -494,7 +497,9 @@ class ValueTests(TestCase):
                 'EMAIL_USE_SSL': False,
                 'EMAIL_USE_TLS': True
             })
-            self.assertEqual(Target.EMAIL_BACKEND, 'django.core.mail.backends.smtp.EmailBackend')
+            self.assertEqual(
+                Target.EMAIL_BACKEND,
+                'django.core.mail.backends.smtp.EmailBackend')
             self.assertEqual(Target.EMAIL_FILE_PATH, '')
             self.assertEqual(Target.EMAIL_HOST, 'smtp.example.com')
             self.assertEqual(Target.EMAIL_HOST_PASSWORD, 'password')

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,9 +1,9 @@
-from django.conf.urls.defaults import include, patterns
+from django.conf.urls import include, url
 
 # Uncomment the next two lines to enable the admin:
 from django.contrib import admin
 admin.autodiscover()
 
-urlpatterns = patterns('',
-    (r'^admin/', include(admin.site.urls)),
-)
+urlpatterns = [
+    url(r'^admin/', include(admin.site.urls)),
+]

--- a/tox.ini
+++ b/tox.ini
@@ -5,26 +5,22 @@ minversion = 1.8
 whitelist_externals=sphinx-build
 envlist =
     flake8-py27,
-    flake8-py35,
+    flake8-py36,
     readme-py27,
-    py33-dj18
-    py{27,34,35,py}-dj{18,19,master}
+    py{27,34,35,36,py}-dj{18,110,111}
+    py{34,35,36}-dj{20,master}
 
 [testenv]
-basepython =
-    py27: python2.7
-    py33: python3.3
-    py34: python3.4
-    py35: python3.5
-    pypy: pypy
 usedevelop = true
 setenv =
     DJANGO_SETTINGS_MODULE = tests.settings.main
     DJANGO_CONFIGURATION = Test
 deps =
     -rtests/requirements.txt
-    dj18: https://github.com/django/django/archive/stable/1.8.x.tar.gz#egg=django
-    dj19: https://github.com/django/django/archive/stable/1.9.x.tar.gz#egg=django
+    dj18: django>=1.8,<1.9
+    dj110: django>=1.10,<1.11
+    dj111: django>=1.11,<2.0
+    dj20: django>=2.0a1,<2.1
     djmaster: https://github.com/django/django/archive/master.tar.gz#egg=django
 
 commands =
@@ -40,7 +36,7 @@ deps = readme_renderer
 commands = flake8 configurations
 deps = flake8
 
-[testenv:flake8-py35]
+[testenv:flake8-py36]
 commands = flake8 configurations
 deps = flake8
 


### PR DESCRIPTION
- Drop django==1.9 as it reached end of life
- Drop python2.6, python3.3 and bring python3.6
- Bring django-2.0 in the matrix as expected failure until we add its
support