### PR TITLE
.coveragerc: use include instead of multiple sources

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,4 @@
 [run]
-source = configurations,tests
+source = .
+include = configurations/*,tests/*
 branch = 1


### PR DESCRIPTION
This will generate a better coverage.xml file, which makes it easier for
codecov hopefully.

Old:

    <sources>
            <source>…/Vcs/django-configurations/configurations</source>
            <source>…/Vcs/django-configurations/tests</source>
    </sources>
    <packages>
            <package branch-rate="0.7178" complexity="0" line-rate="0.8902" name=".">

New:

    <sources>
            <source>…/Vcs/django-configurations</source>
    </sources>
    <packages>
            <package branch-rate="0.712" complexity="0" line-rate="0.8126" name="configurations">

Fixes https://github.com/jazzband/django-configurations/commit/d364802a8aa8562371769f5445efb72a83786576#commitcomment-24826518.