### PR TITLE
extended IntegerValue to only allow positive integers

### DIFF
--- a/configurations/values.py
+++ b/configurations/values.py
@@ -178,6 +178,15 @@ class IntegerValue(CastingMixin, Value):
     caster = int
 
 
+class PositiveIntegerValue(IntegerValue):
+
+    def to_python(self, value):
+        int_value = super(PositiveIntegerValue, self).to_python(value)
+        if int_value < 0:
+            raise ValueError(self.message.format(value))
+        return int_value
+
+
 class FloatValue(CastingMixin, Value):
     caster = float
 

--- a/docs/values.rst
+++ b/docs/values.rst
@@ -230,6 +230,14 @@ Type values
 
         MYSITE_CACHE_TIMEOUT = values.IntegerValue(3600)
 
+.. class:: PositiveIntegerValue
+
+    A :class:`~Value` subclass that handles positive integer values.
+
+    ::
+
+        MYSITE_WORKER_POOL = values.PositiveIntegerValue(8)
+
 .. class:: FloatValue
 
     A :class:`~Value` subclass that handles float values.

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -16,7 +16,7 @@ from configurations.values import (Value, BooleanValue, IntegerValue,
                                    DatabaseURLValue, EmailURLValue,
                                    CacheURLValue, BackendsValue,
                                    CastingMixin, SearchURLValue,
-                                   setup_value)
+                                   setup_value, PositiveIntegerValue)
 
 
 @contextmanager
@@ -134,6 +134,15 @@ class ValueTests(TestCase):
         with env(DJANGO_TEST='2'):
             self.assertEqual(value.setup('TEST'), 2)
         with env(DJANGO_TEST='noninteger'):
+            self.assertRaises(ValueError, value.setup, 'TEST')
+
+    def test_positive_integer_values(self):
+        value = PositiveIntegerValue(1)
+        with env(DJANGO_TEST='2'):
+            self.assertEqual(value.setup('TEST'), 2)
+        with env(DJANGO_TEST='noninteger'):
+            self.assertRaises(ValueError, value.setup, 'TEST')
+        with env(DJANGO_TEST='-1'):
             self.assertRaises(ValueError, value.setup, 'TEST')
 
     def test_float_values(self):


### PR DESCRIPTION
I have recently identified a requirement when working with django-configurations where I needed only a positive integer value.  I thought others may benefit from this feature too.