### PR TITLE
Docs: explicitly describe property in patterns.rst

### DIFF
--- a/docs/patterns.rst
+++ b/docs/patterns.rst
@@ -38,6 +38,22 @@ command line option, e.g.::
 
     python manage.py runserver --settings=mysite.settings --configuration=Prod
 
+Property settings
+-----------------
+
+Use a `property` to allow for computed settings. This pattern can also be used to postpone / lazy evaluate a value. E.g. useful when nesting a Value in a dictionary and a string is required::
+
+    class Prod(Configuration):
+        SENTRY_DSN = values.Value(None, environ_prefix=None)
+
+        @property
+        def RAVEN_CONFIG(self):
+            return {
+                'dsn': self.SENTRY_DSN,
+            }
+
+
+
 Global settings defaults
 ------------------------
 


### PR DESCRIPTION
Hopefully this saves time for new users of django-configuration (like myself), who "just needed" to lazily evaluate a string inside a dictionary.

This doubles as an example for `RAVEN_CONFIG` which was the whole reason I was here in the first place... The actual problem I faced was that a setting remains of type `values.Value` when nested inside a dictionary. Which results in a weird issues like this:

```
Traceback (most recent call last):
    self.client.http_context(self.get_http_context(environ))
  File "/app/.heroku/python/lib/python3.6/site-packages/raven/middleware.py", line 98, in __call__
  File "/app/.heroku/python/lib/python3.6/site-packages/raven/contrib/django/models.py", line 54, in <lambda>
    __getattr__ = lambda x, o: getattr(get_client(), o)
  File "/app/.heroku/python/lib/python3.6/site-packages/raven/contrib/django/models.py", line 134, in get_client
    instance = Client(**options)
  File "/app/.heroku/python/lib/python3.6/site-packages/raven/contrib/django/client.py", line 147, in __init__
    Client.__init__(self, *args, **kwargs)
  File "/app/.heroku/python/lib/python3.6/site-packages/raven/base.py", line 171, in __init__
    self.set_dsn(dsn, transport)
  File "/app/.heroku/python/lib/python3.6/site-packages/raven/base.py", line 251, in set_dsn
    if dsn not in self._transport_cache:
TypeError: unhashable type: 'Value'
```