### PR TITLE
Drop obsolete Django 1.8 and 1.10 from Travis configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,11 +31,27 @@ matrix:
     python: 3.6
   - env: TOXENV=py36-djmaster
     python: 3.6
+  - env: TOXENV=py37-dj20
+    python: 3.7
+    dist: xenial
+    sudo: true
+  - env: TOXENV=py37-dj21
+    python: 3.7
+    dist: xenial
+    sudo: true
+  - env: TOXENV=py37-djmaster
+    python: 3.7
+    dist: xenial
+    sudo: true
   allow_failures:
   - env: TOXENV=py35-djmaster
     python: 3.5
   - env: TOXENV=py36-djmaster
     python: 3.6
+  - env: TOXENV=py37-djmaster
+    python: 3.7
+    dist: xenial
+    sudo: true
 install:
 - pip install tox
 script: tox -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,34 +9,14 @@ matrix:
     python: 3.6
   - env: TOXENV=readme-py27
     python: 2.7
-  - env: TOXENV=py27-dj18
-    python: 2.7
-  - env: TOXENV=py27-dj110
-    python: 2.7
   - env: TOXENV=py27-dj111
     python: 2.7
-  - env: TOXENV=py34-dj18
-    python: 3.4
-  - env: TOXENV=py34-dj110
-    python: 3.4
   - env: TOXENV=py34-dj111
     python: 3.4
-  - env: TOXENV=py35-dj18
-    python: 3.5
-  - env: TOXENV=py35-dj110
-    python: 3.5
   - env: TOXENV=py35-dj111
     python: 3.5
-  - env: TOXENV=py36-dj18
-    python: 3.6
-  - env: TOXENV=py36-dj110
-    python: 3.6
   - env: TOXENV=py36-dj111
     python: 3.6
-  - env: TOXENV=pypy-dj18
-    python: pypy
-  - env: TOXENV=pypy-dj110
-    python: pypy
   - env: TOXENV=pypy-dj111
     python: pypy
   - env: TOXENV=py34-dj20

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,6 +3,11 @@
 Changelog
 ---------
 
+v2.2 (2018-xx-yy)
+^^^^^^^^^^^^^^^^^
+
+- **BACKWARD INCOMPATIBLE** Drop support of Django < 1.11.
+
 v2.1 (2018-08-16)
 ^^^^^^^^^^^^^^^^^
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,11 +2,8 @@ import os
 import subprocess
 import sys
 
-from django import VERSION as DJANGO_VERSION
 from django.test import TestCase
 from django.core.exceptions import ImproperlyConfigured
-
-from unittest import skipIf
 
 from mock import patch
 
@@ -108,21 +105,3 @@ class MainTests(TestCase):
         proc = subprocess.Popen(['django-cadmin', 'runserver', '--help'],
                                 stdout=subprocess.PIPE)
         self.assertIn('--configuration', proc.communicate()[0].decode('utf-8'))
-
-    @skipIf(DJANGO_VERSION >= (1, 10), 'only applies to Django < 1.10')
-    def test_deprecated_option_list_command(self):
-        """
-        Verify that the configuration option is correctly added to any
-        management commands which are still relying on option_list to
-        add their own custom arguments
-
-        Specific test for a pattern which was deprecated in Django 1.8
-        and which will become completely unsupported in Django 1.10.
-        https://docs.djangoproject.com/en/1.8/howto/custom-management-commands/#custom-commands-options
-        """
-        proc = subprocess.Popen(
-            ['django-cadmin', 'old_optparse_command', '--help'],
-            stdout=subprocess.PIPE)
-        output = proc.communicate()[0].decode('utf-8')
-        self.assertIn('--configuration', output)
-        self.assertIn('--arg1', output)


### PR DESCRIPTION
Per https://www.djangoproject.com/download/, Django 1.8 support ended in April 2018 and Django 1.10 support ended in December 2017.  

Django master also now explicitly [requires](https://github.com/django/django/commit/32ade4d73b50aed77efdb9dd7371c17f89061afc) Django 3.5+, so drop testing against Django master on Python 3.4.

Let's drop those test cases from Travis.

NOTE: I would add support for Python 3.7 in Travis as well, but that's not available upstream yet. ref: https://github.com/travis-ci/travis-ci/issues/9815