### PR TITLE
Fix utils.reraise for exceptions without args

### DIFF
--- a/configurations/utils.py
+++ b/configurations/utils.py
@@ -62,7 +62,7 @@ def reraise(exc, prefix=None, suffix=None):
         suffix = ''
     elif not (suffix.startswith('(') and suffix.endswith(')')):
         suffix = '(' + suffix + ')'
-    exc.args = ('{0} {1} {2}'.format(prefix, exc.args[0], suffix),) + args[1:]
+    exc.args = ('{0} {1} {2}'.format(prefix, args[0], suffix),) + args[1:]
     raise
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -118,3 +118,17 @@ class MainTests(TestCase):
         self.assertIn('setup_2', stdout)
         self.assertIn('setup_done', stdout)
         self.assertEqual(proc.returncode, 0)
+
+    def test_utils_reraise(self):
+        from configurations.utils import reraise
+
+        class CustomException(Exception):
+            pass
+
+        with self.assertRaises(CustomException) as cm:
+            try:
+                raise CustomException
+            except Exception as exc:
+                reraise(exc, "Couldn't setup configuration", None)
+
+        self.assertEqual(cm.exception.args, ("Couldn't setup configuration:   ",))


### PR DESCRIPTION
This is the case for e.g. `bdb.BdbQuit`.