### PR TITLE
Fix error with imp deprecation

### DIFF
--- a/configurations/importer.py
+++ b/configurations/importer.py
@@ -136,7 +136,7 @@ class ConfigurationImporter(object):
         if fullname is not None and fullname == self.module:
             module = fullname.rsplit('.', 1)[-1]
             return ConfigurationLoader(self.name,
-                                       imp.find_module(module, path))
+                                       imp.find_module(module, path._path))
         return None
 
 


### PR DESCRIPTION
With a new django project I was getting this error on startup

  File "/Users/marty/getasnap/user-api/pyenv/lib/python3.6/site-packages/configurations/importer.py", line 141, in find_module
    imp.find_module(module, path))
  File "/Users/marty/.pyenv/versions/3.6.5/lib/python3.6/imp.py", line 271, in find_module
    "not {}".format(type(path)))
RuntimeError: 'path' must be None or a list, not <class '_frozen_importlib_external._NamespacePath'>

It looks like the find_module function in imp will be deprecated, but this fix works for me... Not sure if its really the right thing to merge into the main project, but it helps me move forward...