### PR TITLE
Remove deprecated import (gone in Django 1.9)

### DIFF
--- a/configurations/utils.py
+++ b/configurations/utils.py
@@ -1,12 +1,10 @@
 import inspect
 import sys
 
+from importlib import import_module
+
 from django.core.exceptions import ImproperlyConfigured
 from django.utils import six
-try:
-    from importlib import import_module
-except ImportError:
-    from django.utils.importlib import import_module
 
 
 def isuppercase(name):


### PR DESCRIPTION
Looks like we're fine without `django.utils.importlib`, which is removed in Django 1.9 and deprecated since at least Django 1.7.

Relates to issue #190.