### PR TITLE
Validate IntegerValue during class initialization

### DIFF
--- a/configurations/values.py
+++ b/configurations/values.py
@@ -176,9 +176,16 @@ class CastingMixin(object):
 
 class IntegerValue(CastingMixin, Value):
     caster = int
+    message = 'Cannot interpret integer value {0!r}'
+
+    def __init__(self, *args, **kwargs):
+        super(IntegerValue, self).__init__(*args, **kwargs)
+        if self.default is not None:
+            self.default = self.to_python(str(self.default))
 
 
 class PositiveIntegerValue(IntegerValue):
+    message = 'Cannot interpret positive integer value {0!r}'
 
     def to_python(self, value):
         int_value = super(PositiveIntegerValue, self).to_python(value)
@@ -189,11 +196,23 @@ class PositiveIntegerValue(IntegerValue):
 
 class FloatValue(CastingMixin, Value):
     caster = float
+    message = 'Cannot interpret float value {0!r}'
+
+    def __init__(self, *args, **kwargs):
+        super(FloatValue, self).__init__(*args, **kwargs)
+        if self.default is not None:
+            self.default = self.to_python(str(self.default))
 
 
 class DecimalValue(CastingMixin, Value):
     caster = decimal.Decimal
     exception = decimal.InvalidOperation
+    message = 'Cannot interpret decimal value {0!r}'
+
+    def __init__(self, *args, **kwargs):
+        super(DecimalValue, self).__init__(*args, **kwargs)
+        if self.default is not None:
+            self.default = self.to_python(str(self.default))
 
 
 class SequenceValue(Value):

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -129,12 +129,31 @@ class ValueTests(TestCase):
         self.assertFalse(value1.setup('TEST1'))
         self.assertFalse(value2.setup('TEST2'))
 
+    def test_direct_integer_values(self):
+        error_values = ('1.5', float(1.5))
+        values = ('1', 1)
+        for each in error_values:
+            self.assertRaises(ValueError, IntegerValue, each)
+        for each in values:
+            self.assertEqual(IntegerValue(each), int(each))
+
+    def test_direct_empty__integer_value(self):
+        self.assertEqual(IntegerValue(), None)
+
     def test_integer_values(self):
         value = IntegerValue(1)
         with env(DJANGO_TEST='2'):
             self.assertEqual(value.setup('TEST'), 2)
         with env(DJANGO_TEST='noninteger'):
             self.assertRaises(ValueError, value.setup, 'TEST')
+
+    def test_direct_positive_integer_values(self):
+        error_values = ('-1.5', float(-1.5), '1.5', float(1.5))
+        values = ('1', 1)
+        for each in error_values:
+            self.assertRaises(ValueError, PositiveIntegerValue, each)
+        for each in values:
+            self.assertEqual(PositiveIntegerValue(each), int(each))
 
     def test_positive_integer_values(self):
         value = PositiveIntegerValue(1)
@@ -145,12 +164,34 @@ class ValueTests(TestCase):
         with env(DJANGO_TEST='-1'):
             self.assertRaises(ValueError, value.setup, 'TEST')
 
+    def test_direct_float_values(self):
+        values = ('1', 1, '-1', -1, '-1.5', -1.5, '1.5', 1.5)
+        error_values = (True, 'aword')
+        for each in error_values:
+            self.assertRaises(ValueError, FloatValue, each)
+        for each in values:
+            self.assertEqual(FloatValue(each), float(each))
+
+    def test_direct_empty__float_value(self):
+        self.assertEqual(FloatValue(), None)
+
     def test_float_values(self):
         value = FloatValue(1.0)
         with env(DJANGO_TEST='2.0'):
             self.assertEqual(value.setup('TEST'), 2.0)
         with env(DJANGO_TEST='noninteger'):
             self.assertRaises(ValueError, value.setup, 'TEST')
+
+    def test_direct_decimal_values(self):
+        values = ('1', 1, '-1', -1, '-1.5', -1.5, '1.5', 1.5)
+        error_values = (True, 'aword')
+        for each in error_values:
+            self.assertRaises(ValueError, DecimalValue, each)
+        for each in values:
+            self.assertEqual(DecimalValue(each), decimal.Decimal(each))
+
+    def test_direct_empty__decimal_value(self):
+        self.assertEqual(DecimalValue(), None)
 
     def test_decimal_values(self):
         value = DecimalValue(decimal.Decimal(1))


### PR DESCRIPTION
#225  Validation is not performed during the initialization of `values.IntegerValue` and `values.PositiveIntegerValue`.