### PR TITLE
Update tested Python & Django versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,12 @@ matrix:
     python: 2.7
   - env: TOXENV=py27-dj111-coverage
     python: 2.7
-  - env: TOXENV=py34-dj111-coverage
-    python: 3.4
   - env: TOXENV=py35-dj111-coverage
     python: 3.5
   - env: TOXENV=py36-dj111-coverage
     python: 3.6
   - env: TOXENV=pypy-dj111-coverage
     python: pypy
-  - env: TOXENV=py34-dj20-coverage
-    python: 3.4
-  - env: TOXENV=py35-dj20-coverage
     python: 3.5
   - env: TOXENV=py35-djmaster-coverage
     python: 3.5
@@ -39,6 +34,14 @@ matrix:
     python: 3.7
     dist: xenial
     sudo: true
+  - env: TOXENV=py38-dj22-coverage
+    python: 3.8
+    dist: xenial
+    sudo: true
+  - env: TOXENV=py38-dj30-coverage
+    python: 3.8
+    dist: xenial
+    sudo: true
   allow_failures:
   - env: TOXENV=py35-djmaster-coverage
     python: 3.5
@@ -46,8 +49,8 @@ matrix:
     python: 3.6
   - env: TOXENV=py37-djmaster-coverage
     python: 3.7
-    dist: xenial
-    sudo: true
+  - env: TOXENV=py38-djmaster-coverage
+    python: 3.8
 install:
 - pip install tox
 script: tox -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,38 +13,55 @@ matrix:
     python: 3.6
   - env: TOXENV=pypy-dj111-coverage
     python: pypy
-  - env: TOXENV=py35-djmaster-coverage
+  - env: TOXENV=pypy3-dj111-coverage
+    python: pypy3
+  - env: TOXENV=py35-dj20-coverage
     python: 3.5
   - env: TOXENV=py36-dj20-coverage
     python: 3.6
-  - env: TOXENV=py36-dj21-coverage
-    python: 3.6
-  - env: TOXENV=py36-djmaster-coverage
-    python: 3.6
   - env: TOXENV=py37-dj20-coverage
     python: 3.7
-    sudo: true
+  - env: TOXENV=pypy3-dj20-coverage
+    python: pypy3
+  - env: TOXENV=py36-dj21-coverage
+    python: 3.6
   - env: TOXENV=py37-dj21-coverage
     python: 3.7
-    sudo: true
-  - env: TOXENV=py37-djmaster-coverage
+  - env: TOXENV=pypy3-dj21-coverage
+    python: pypy3
+  - env: TOXENV=py36-dj22-coverage
+    python: 3.6
+  - env: TOXENV=py37-dj22-coverage
     python: 3.7
-    sudo: true
   - env: TOXENV=py38-dj22-coverage
     python: 3.8
-    sudo: true
+  - env: TOXENV=pypy3-dj22-coverage
+    python: pypy3
+  - env: TOXENV=py36-dj30-coverage
+    python: 3.6
+  - env: TOXENV=py37-dj30-coverage
+    python: 3.7
   - env: TOXENV=py38-dj30-coverage
     python: 3.8
-    sudo: true
-  allow_failures:
-  - env: TOXENV=py35-djmaster-coverage
-    python: 3.5
+  - env: TOXENV=pypy3-dj30-coverage
+    python: pypy3
   - env: TOXENV=py36-djmaster-coverage
     python: 3.6
   - env: TOXENV=py37-djmaster-coverage
     python: 3.7
   - env: TOXENV=py38-djmaster-coverage
     python: 3.8
+  - env: TOXENV=pypy3-djmaster-coverage
+    python: pypy3
+  allow_failures:
+  - env: TOXENV=py36-djmaster-coverage
+    python: 3.6
+  - env: TOXENV=py37-djmaster-coverage
+    python: 3.7
+  - env: TOXENV=py38-djmaster-coverage
+    python: 3.8
+  - env: TOXENV=pypy3-djmaster-coverage
+    python: pypy3
 install:
 - pip install tox
 script: tox -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ matrix:
     python: 3.6
   - env: TOXENV=pypy-dj111-coverage
     python: pypy
-    python: 3.5
   - env: TOXENV=py35-djmaster-coverage
     python: 3.5
   - env: TOXENV=py36-dj20-coverage
@@ -24,23 +23,18 @@ matrix:
     python: 3.6
   - env: TOXENV=py37-dj20-coverage
     python: 3.7
-    dist: xenial
     sudo: true
   - env: TOXENV=py37-dj21-coverage
     python: 3.7
-    dist: xenial
     sudo: true
   - env: TOXENV=py37-djmaster-coverage
     python: 3.7
-    dist: xenial
     sudo: true
   - env: TOXENV=py38-dj22-coverage
     python: 3.8
-    dist: xenial
     sudo: true
   - env: TOXENV=py38-dj30-coverage
     python: 3.8
-    dist: xenial
     sudo: true
   allow_failures:
   - env: TOXENV=py35-djmaster-coverage

--- a/configurations/base.py
+++ b/configurations/base.py
@@ -1,7 +1,7 @@
 import os
 import re
+import six
 
-from django.utils import six
 from django.conf import global_settings
 from django.core.exceptions import ImproperlyConfigured
 

--- a/configurations/utils.py
+++ b/configurations/utils.py
@@ -1,10 +1,10 @@
 import inspect
+import six
 import sys
 
 from importlib import import_module
 
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import six
 
 
 def isuppercase(name):

--- a/configurations/values.py
+++ b/configurations/values.py
@@ -2,11 +2,11 @@ import ast
 import copy
 import decimal
 import os
+import six
 import sys
 
 from django.core import validators
 from django.core.exceptions import ValidationError, ImproperlyConfigured
-from django.utils import six
 
 from .utils import import_by_path, getargspec
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,10 +3,20 @@
 Changelog
 ---------
 
-v2.2 (2018-xx-yy)
+v2.2 (2019-xx-yy)
 ^^^^^^^^^^^^^^^^^
 
-- **BACKWARD INCOMPATIBLE** Drop support of Django < 1.11.
+- **BACKWARD INCOMPATIBLE** Drop support for Python 3.4.
+
+- **BACKWARD INCOMPATIBLE** Drop support for Django < 1.11.
+
+- Add support for Django 3.0.
+
+- Add support for Python Python 3.8.
+
+- Add support for Python PyPy 3.
+
+- Replace ``django.utils.six`` with ``six`` to support Django >= 3.
 
 v2.1 (2018-08-16)
 ^^^^^^^^^^^^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,8 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Utilities',
     ],
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
             'django-cadmin = configurations.management:execute_from_command_line',
         ],
     },
+    install_requires=['six'],
     extras_require={
         'cache': ['django-cache-url'],
         'database': ['dj-database-url'],
@@ -53,7 +54,6 @@ setup(
             'dj-database-url',
             'dj-email-url',
             'dj-search-url',
-            'six',
             'Sphinx>=1.4',
         ],
     },

--- a/tests/settings/main.py
+++ b/tests/settings/main.py
@@ -31,7 +31,6 @@ class Test(Configuration):
         'django.contrib.contenttypes',
         'django.contrib.sites',
         'django.contrib.auth',
-        'django.contrib.admin',
         'tests',
     ]
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,6 +1,2 @@
-from django.conf.urls import url
-from django.contrib import admin
-
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,10 @@ whitelist_externals = sphinx-build
 envlist =
     checkqa,
     readme-py27,
-    py{27,34,35,36,py}-dj{18,110,111}
-    py{34,35,36,37}-dj20
-    py{35,36,37}-dj{21,master}
+    py{27,34,35,36,py}-dj111
+    py{34,35,36,37,py3}-dj20
+    py{35,36,37,py3}-dj{21,22}
+    py{36,37,38,py3}-dj{30,master}
 
 [testenv]
 usedevelop = true
@@ -18,11 +19,11 @@ setenv =
     coverage: COVERAGE_PROCESS_START = {toxinidir}/setup.cfg
     coverage: _TEST_RUN_PREFIX=coverage run
 deps =
-    dj18: django>=1.8,<1.9
-    dj110: django>=1.10,<1.11
     dj111: django>=1.11,<2.0
     dj20: django>=2.0a1,<2.1
     dj21: django>=2.1a1,<2.2
+    dj22: django>=2.2a1,<3.0
+    dj30: django>=3.0a1<3.1
     djmaster: https://github.com/django/django/archive/master.tar.gz#egg=django
     py27,pypy: mock
     coverage: coverage

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,10 @@ whitelist_externals = sphinx-build
 envlist =
     checkqa,
     readme-py27,
-    py{27,34,35,36,py}-dj111
-    py{34,35,36,37,py3}-dj20
-    py{35,36,37,py3}-dj{21,22}
+    py{27,35,36,py}-dj111
+    py{35,36,37,py3}-dj20
+    py{35,36,37,py3}-dj21
+    py{35,36,37,38,py3}-dj22
     py{36,37,38,py3}-dj{30,master}
 
 [testenv]
@@ -23,7 +24,7 @@ deps =
     dj20: django>=2.0a1,<2.1
     dj21: django>=2.1a1,<2.2
     dj22: django>=2.2a1,<3.0
-    dj30: django>=3.0a1<3.1
+    dj30: django>=3.0a1,<3.1
     djmaster: https://github.com/django/django/archive/master.tar.gz#egg=django
     py27,pypy: mock
     coverage: coverage


### PR DESCRIPTION
Replaces `django.utils.six` with `six` to support newer Django versions.

Updates Tox config to:
- remove unsupported Django versions
- add pypy3
- add Django 2.2
- update djmaster Python versions with those supported by Django 3.0

Comments admin app & URLs in test directory to avoid errors raised by missing settings required by the Django admin.

Closes #241 