### PR TITLE
docs: Fix simple typo, wheter -> whether

### DIFF
--- a/docs/values.rst
+++ b/docs/values.rst
@@ -162,7 +162,7 @@ the prefix.
    :param environ: toggle for environment use
    :param environ_name: name of environment variable to look for
    :param environ_prefix: prefix to use when looking for environment variable
-   :param environ_required: wheter or not the value is required to be set as an environment variable
+   :param environ_required: whether or not the value is required to be set as an environment variable
    :type environ: bool
    :type environ_name: capitalized string or None
    :type environ_prefix: capitalized string


### PR DESCRIPTION
There is a small typo in docs/values.rst.

Should read `whether` rather than `wheter`.

