### PR TITLE
testing: remove django-discover-runner

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
         'email': ['dj-email-url'],
         'search': ['dj-search-url'],
         'testing': [
-            'django-discover-runner',
             'mock',
             'django-cache-url>=1.0.0',
             'dj-database-url',


### PR DESCRIPTION
project supports Django 1.11+

> https://pypi.org/project/django-discover-runner/

This runner has been added to Django 1.6 as the default test runner.
If you use Django 1.6 or above you don’t need this app.

fix #250