### PR TITLE
Fixed malformed links in documentation

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -332,8 +332,8 @@ Channels
 --------
 
 If you want to deploy a project that uses the Django channels with
-`Daphne <http://github.com/django/daphne/>` as the
-`interface server <http://channels.readthedocs.io/en/latest/deploying.html#run-interface-servers>`
+`Daphne <http://github.com/django/daphne/>`_ as the
+`interface server <http://channels.readthedocs.io/en/latest/deploying.html#run-interface-servers>`_
 you have to use a asgi.py script similar to the following:
 
 .. code-block:: python


### PR DESCRIPTION
I noticed two links that were rendered incorrectly on https://django-configurations.readthedocs.io/en/latest/cookbook/#channels.

I tried to find if there might be other instances of the same typo using `git grep -E '>`([^_]|$)' -- docs/` but it seems these two were the only ones (this command yields a few false positives).