### PR TITLE
fix version string at runtime

### DIFF
--- a/configurations/version.py
+++ b/configurations/version.py
@@ -1,7 +1,7 @@
 from pkg_resources import get_distribution, DistributionNotFound
 
 try:
-    __version__ = get_distribution(__name__).version
+    __version__ = get_distribution("django-configurations").version
 except DistributionNotFound:
     # package is not installed
     __version__ = None


### PR DESCRIPTION
I noticed when running `manage.py runserver` in my own project, the version string was missing from the announcement. I was seeing the message `django-configurations version , using configuration LocalDev` in my logs. I checked the result of `get_distribution("configurations.version")` within a python shell, and discovered it was raising the following exception string `pkg_resources.DistributionNotFound: The 'configurations.version' distribution was not found and is required by the application`.

This patch should fix the `__version__` variable. I noticed in the commit that introduced this change, the `docs/conf.py` file had the correct use of the `get_distribution` call so I just used it in the `version.py` file as well: https://github.com/jazzband/django-configurations/commit/42641f5eb458916a62edc2bfd35d6a619e5a8855#diff-85987f48f1258d9ee486e3191495582dR54.