### PR TITLE
create a django-stubs compatibility plugin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,5 +120,16 @@ The same applies to your **wsgi.py** file, e.g.:
 Here we don't use the default ``django.core.wsgi.get_wsgi_application``
 function but instead ``configurations.wsgi.get_wsgi_application``.
 
+If you're using configurations with `django-stubs <https://github.com/typeddjango/django-stubs>`_,
+you need to add the django_stubs_compat plugin to your mypy configuration
+in your setup.cfg or pyproject.toml:
+
+.. code-block:: ini
+
+    [mypy]
+    plugins = configurations.django_stubs_compat, mypy_django_plugin.main
+
+Note that the django_stubs_compat plugin is added before the mypy_django_plugin.
+
 That's it! You can now use your project with ``manage.py`` and your favorite
 WSGI enabled server.

--- a/configurations/django_stubs_compat.py
+++ b/configurations/django_stubs_compat.py
@@ -1,0 +1,18 @@
+"""This file defines a plugin to allow compatibility between configurations and django-stubs."""
+
+from configurations import importer
+from mypy.plugin import Options, Plugin
+
+
+class DjangoStubsCompatPlugin(Plugin):
+    """Run the importer install before the django-stubs plugin is imported."""
+
+    def __init__(self, options: Options) -> None:
+        """Init the superclass, and install the importer."""
+        super().__init__(options)
+        importer.install()
+
+
+def plugin(version) -> DjangoStubsCompatPlugin:
+    """Return the plugin."""
+    return DjangoStubsCompatPlugin


### PR DESCRIPTION
closes #267

this creates a mypy plugin to add compatibility with the django-stubs package. currently, mypy will completely crash when attempting to run on a project using both django-stubs and django-configurations this is because configurations is never initialized by django-stubs

this plugin (when added to setup.cfg correctly) runs before the django-stubs plugin and initializes the importer correctly, allowing mypy to run