### PR TITLE
Replace references to MIDDLEWARE_CLASSES with MIDDLEWARE

### DIFF
--- a/docs/values.rst
+++ b/docs/values.rst
@@ -547,7 +547,7 @@ Other values
 
     ::
 
-        MIDDLEWARE_CLASSES = values.BackendsValue([
+        MIDDLEWARE = values.BackendsValue([
             'django.middleware.common.CommonMiddleware',
             'django.contrib.sessions.middleware.SessionMiddleware',
             'django.middleware.csrf.CsrfViewMiddleware',

--- a/test_project/test_project/settings.py
+++ b/test_project/test_project/settings.py
@@ -95,7 +95,7 @@ class Base(Configuration):
         'django.template.loaders.app_directories.Loader',
     )
 
-    MIDDLEWARE_CLASSES = (
+    MIDDLEWARE = (
         'django.middleware.common.CommonMiddleware',
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',


### PR DESCRIPTION
MIDDLEWARE_CLASSES was removed in Django 2.0.