### PR TITLE
Add ASGI support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ command line option, e.g.
     python manage.py runserver --settings=mysite.settings --configuration=Dev
 
 To enable Django to use your configuration you now have to modify your
-**manage.py** or **wsgi.py** script to use django-configurations's versions
+**manage.py**, **wsgi.py** or **asgi.py** script to use django-configurations's versions
 of the appropriate starter functions, e.g. a typical **manage.py** using
 django-configurations would look like this:
 

--- a/README.rst
+++ b/README.rst
@@ -120,5 +120,18 @@ The same applies to your **wsgi.py** file, e.g.:
 Here we don't use the default ``django.core.wsgi.get_wsgi_application``
 function but instead ``configurations.wsgi.get_wsgi_application``.
 
+Or if you are not serving your app via WSGI but ASGI instead, you need to modify your **asgi.py** file too.:
+
+.. code-block:: python
+
+    import os
+
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'mysite.settings')
+    os.environ.setdefault('DJANGO_CONFIGURATION', 'DEV')
+
+    from configurations.asgi import get_asgi_application
+
+    application = get_asgi_application()
+
 That's it! You can now use your project with ``manage.py`` and your favorite
-WSGI enabled server.
+WSGI/ASGI enabled server.

--- a/configurations/asgi.py
+++ b/configurations/asgi.py
@@ -2,13 +2,7 @@ from . import importer
 
 importer.install()
 
-try:
-    from django.core.asgi import get_asgi_application
-except ImportError:  # pragma: no cover
-    from django.core.handlers.asgi import ASGIHandler
-
-    def get_asgi_application():  # noqa
-        return ASGIHandler()
+from django.core.asgi import get_asgi_application
 
 # this is just for the crazy ones
 application = get_asgi_application()

--- a/configurations/asgi.py
+++ b/configurations/asgi.py
@@ -1,0 +1,14 @@
+from . import importer
+
+importer.install()
+
+try:
+    from django.core.asgi import get_asgi_application
+except ImportError:  # pragma: no cover
+    from django.core.handlers.asgi import ASGIHandler
+
+    def get_asgi_application():  # noqa
+        return ASGIHandler()
+
+# this is just for the crazy ones
+application = get_asgi_application()

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -182,7 +182,7 @@ probably just add the following to the **beginning** of your settings module:
     import configurations
     configurations.setup()
 
-That has the same effect as using the ``manage.py`` or ``wsgi.py`` utilities.
+That has the same effect as using the ``manage.py``, ``wsgi.py`` or ``asgi.py`` utilities.
 This will also call ``django.setup()``.
 
 >= 3.1


### PR DESCRIPTION
Since #251 has not seen any recent activity, I have decided to take over the PR.
This PR still has the same intention of enabling users to easily use django-configurations with asgi based applications.
Additionally I have added some documentation around how to use django-configurations with asgi.

Regarding the question from @carltongibson Django ships with `get_asgi_application` since version 3.0 and up until now. `get_asgi_application` is also intended as the public interface while `ASGIHandler` is supposed to be private django internals.

Regarding the failing codecov checks, I saw that the wsgi handler does not have any tests either and I don't yet know enough about this project's structure to create new tests for asgi and wsgi handlers. This can maybe be done in a later PR though.