### PR TITLE
Change configurations.setup() to importer.install()

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -209,8 +209,8 @@ Celery's documentation`_:
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'mysite.settings')
     os.environ.setdefault('DJANGO_CONFIGURATION', 'MySiteConfiguration')
 
-    import configurations
-    configurations.setup()
+    from configurations import importer
+    importer.install()
 
     app = Celery('mysite')
     app.config_from_object('django.conf:settings')


### PR DESCRIPTION
Trying to run example from the docs with Celery results in error message:
```
django.core.exceptions.ImproperlyConfigured: django-configurations settings importer wasn't correctly installed. Please use one of the starter functions to install it as mentioned in the docs: https://django-configurations.readthedocs.io/
```

However, changing that to:
```
from configurations import importer
importer.install()
```

works fine.

This PR updates the documentation to provide correct command.