### PR TITLE
Don't run duplicate CI tasks on every PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
The `pull_request` action already runs on pushes to any branch with an open PR, so only run the `push` action on the `master` branch.