### PR TITLE
Simplify import of django.core.wsgi.get_wsgi_application

### DIFF
--- a/configurations/wsgi.py
+++ b/configurations/wsgi.py
@@ -2,13 +2,7 @@ from . import importer
 
 importer.install()
 
-try:
-    from django.core.wsgi import get_wsgi_application
-except ImportError:  # pragma: no cover
-    from django.core.handlers.wsgi import WSGIHandler
-
-    def get_wsgi_application():  # noqa
-        return WSGIHandler()
+from django.core.wsgi import get_wsgi_application    # noqa: E402
 
 # this is just for the crazy ones
 application = get_wsgi_application()


### PR DESCRIPTION
This has been available since Django 1.4. The import guard is no longer necessary.