### PR TITLE
Remove references to TEMPLATE_DEBUG

### DIFF
--- a/docs/patterns.rst
+++ b/docs/patterns.rst
@@ -21,7 +21,6 @@ file:
 
     class Dev(Base):
         DEBUG = True
-        TEMPLATE_DEBUG = DEBUG
 
     class Prod(Base):
         TIME_ZONE = 'America/New_York'

--- a/docs/values.rst
+++ b/docs/values.rst
@@ -46,7 +46,6 @@ value:
 
     class Dev(Configuration):
         DEBUG = values.BooleanValue(True)
-        TEMPLATE_DEBUG = values.BooleanValue(DEBUG)
 
 See the list of :ref:`built-in value classes<built-ins>` for more information.
 

--- a/test_project/test_project/settings.py
+++ b/test_project/test_project/settings.py
@@ -5,7 +5,6 @@ class Base(Configuration):
     # Django settings for test_project project.
 
     DEBUG = values.BooleanValue(True, environ=True)
-    TEMPLATE_DEBUG = DEBUG
 
     ADMINS = (
         # ('Your Name', 'your_email@example.com'),


### PR DESCRIPTION
This setting is deprecated since Django 1.8.

Fixes #216.