### PR TITLE
Remove "mock" as a test requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
         'email': ['dj-email-url'],
         'search': ['dj-search-url'],
         'testing': [
-            'mock',
             'django-cache-url>=1.0.0',
             'dj-database-url',
             'dj-email-url',


### PR DESCRIPTION
This is included in the standard library of Python 3.3+.