### PR TITLE
Restore an example of a dependent setting to the docs

### DIFF
--- a/docs/values.rst
+++ b/docs/values.rst
@@ -46,6 +46,7 @@ value:
 
     class Dev(Configuration):
         DEBUG = values.BooleanValue(True)
+        DEBUG_PROPAGATE_EXCEPTIONS = values.BooleanValue(DEBUG)
 
 See the list of :ref:`built-in value classes<built-ins>` for more information.
 


### PR DESCRIPTION
This was removed by #303. This now uses a real Django setting, `DEBUG_PROPAGATE_EXCEPTIONS`"`, instead of a deprecated one.