### PR TITLE
docs: Fix a few typos

### DIFF
--- a/configurations/base.py
+++ b/configurations/base.py
@@ -100,7 +100,7 @@ class Configuration(metaclass=ConfigurationBase):
         http://www.wellfireinteractive.com/blog/easier-12-factor-django/
         https://gist.github.com/bennylope/2999704
         """
-        # check if the class has DOTENV set wether with a path or None
+        # check if the class has DOTENV set whether with a path or None
         dotenv = getattr(cls, 'DOTENV', None)
 
         # if DOTENV is falsy we want to disable it

--- a/configurations/values.py
+++ b/configurations/values.py
@@ -112,7 +112,7 @@ class Value:
         """
         Convert the given value of a environment variable into an
         appropriate Python representation of the value.
-        This should be overriden when subclassing.
+        This should be overridden when subclassing.
         """
         return value
 

--- a/docs/patterns.rst
+++ b/docs/patterns.rst
@@ -3,7 +3,7 @@ Usage patterns
 
 There are various configuration patterns that can be implemented with
 django-configurations. The most common pattern is to have a base class
-and various subclasses based on the enviroment they are supposed to be
+and various subclasses based on the environment they are supposed to be
 used in, e.g. in production, staging and development.
 
 Server specific settings


### PR DESCRIPTION
There are small typos in:
- configurations/base.py
- configurations/values.py
- docs/patterns.rst

Fixes:
- Should read `whether` rather than `wether`.
- Should read `overridden` rather than `overriden`.
- Should read `environment` rather than `enviroment`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md