### PR TITLE
Fix "STATICFILES_STORAGE/STORAGES are mutually exclusive" on Django>=4.2

### DIFF
--- a/configurations/base.py
+++ b/configurations/base.py
@@ -52,6 +52,12 @@ class ConfigurationBase(type):
         # https://github.com/django/django/commit/226ebb17290b604ef29e82fb5c1fbac3594ac163#diff-ec2bed07bb264cb95a80f08d71a47c06R163-R170
         if "PASSWORD_RESET_TIMEOUT" in settings_vars:
             deprecated_settings.add("PASSWORD_RESET_TIMEOUT_DAYS")
+        # DEFAULT_FILE_STORAGE and STATICFILES_STORAGE are deprecated
+        # in favor of STORAGES.
+        # https://docs.djangoproject.com/en/dev/releases/4.2/#custom-file-storages
+        if "STORAGES" in settings_vars:
+            deprecated_settings.add("DEFAULT_FILE_STORAGE")
+            deprecated_settings.add("STATICFILES_STORAGE")
         for deprecated_setting in deprecated_settings:
             if deprecated_setting in settings_vars:
                 del settings_vars[deprecated_setting]

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,7 @@ Changelog
 unreleased
 ^^^^^^^^^^
 
+- Add compatibility with Django 4.2 - fix "STATICFILES_STORAGE/STORAGES are mutually exclusive" error.
 - Test Django 4.1.3+ on Python 3.11
 
 v2.4 (2022-08-24)

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,7 @@ deps =
     dj32: django~=3.2.9
     dj40: django~=4.0.0
     dj41: django~=4.1.3
+    dj42: django~=4.2.0a1
     djmain: https://github.com/django/django/archive/main.tar.gz
     coverage
     coverage_enable_subprocess

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,9 @@ envlist =
     py37-checkqa
     docs
     py{37,py37}-dj{32}
-    py{38,py38,39,py39,310}-dj{32,40,41}
-    py{311}-dj{41}
+    py{38,py38,39,py39}-dj{32,40,41,42}
+    py{310}-dj{32,40,41,42,main}
+    py{311}-dj{41,42,main}
 
 [gh-actions]
 python =


### PR DESCRIPTION
This fixes

```
django.core.exceptions.ImproperlyConfigured: STATICFILES_STORAGE/STORAGES are mutually exclusive.
```

when running on Django 4.2 or later. See https://docs.djangoproject.com/en/dev/releases/4.2/#custom-file-storages

This currently blocks pytest-django support for 4.2 (pytest-django has django-configurations support), so a release including this change will be appreciated!