### PR TITLE
Prevent FORMS_URLFIELD_ASSUME_HTTPS warning on Django 5.0

### DIFF
--- a/configurations/base.py
+++ b/configurations/base.py
@@ -46,6 +46,10 @@ class ConfigurationBase(type):
             # suppressed, as downstream users are expected to make a decision.
             # https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys
             "DEFAULT_AUTO_FIELD",
+            # FORMS_URLFIELD_ASSUME_HTTPS is a transitional setting introduced
+            # in Django 5.0.
+            # https://docs.djangoproject.com/en/5.0/releases/5.0/#id2
+            "FORMS_URLFIELD_ASSUME_HTTPS"
         }
         # PASSWORD_RESET_TIMEOUT_DAYS is deprecated in favor of
         # PASSWORD_RESET_TIMEOUT in Django 3.1

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,6 +3,11 @@
 Changelog
 ---------
 
+Unreleased
+^^^^^^^^^^
+
+- Prevent warning about ``FORMS_URLFIELD_ASSUME_HTTPS`` on Django 5.0.
+
 v2.5.1 (2023-11-30)
 ^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Prevent this warning:

```
$ python -Wall manage.py help
/.../django/conf/__init__.py:214: RemovedInDjango60Warning: The FORMS_URLFIELD_ASSUME_HTTPS transitional setting is deprecated.
  warnings.warn(
...
```

The approach of listing the setting in `deprecated_settings` is the same as for `STORAGES` in #349, but it does not need to be conditional.