### PR TITLE
Fix code coverage and newly failing test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,10 @@ jobs:
         tox --verbose
 
     - name: Upload coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
-        name: Python ${{ matrix.python-version }}
+        name: coverage-data-${{ matrix.python-version }}
+        path: ".coverage.*"
+        include-hidden-files: true
+        merge-multiple: true
         fail_ci_if_error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,3 +54,4 @@ jobs:
         include-hidden-files: true
         merge-multiple: true
         fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -374,9 +374,10 @@ class ValueTests(TestCase):
         self.assertEqual(value.default, {})
         with env(DATABASE_URL='sqlite://'):
             settings_value = value.setup('DATABASE_URL')
-            # Compare the embedded dicts in the "default" entry so that the difference can be seen if 
+            # Compare the embedded dicts in the "default" entry so that the difference can be seen if
             # it fails ... DatabaseURLValue(|) uses an external app that can add additional entries
-            self.assertDictEqual({
+            self.assertDictEqual(
+                {
                     'CONN_HEALTH_CHECKS': False,
                     'CONN_MAX_AGE': 0,
                     'DISABLE_SERVER_SIDE_CURSORS': False,
@@ -386,7 +387,9 @@ class ValueTests(TestCase):
                     'PASSWORD': '',
                     'PORT': '',
                     'USER': '',
-                }, settings_value['default'])
+                },
+                settings_value['default']
+            )
 
     def test_database_url_additional_args(self):
 

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -373,17 +373,20 @@ class ValueTests(TestCase):
         value = DatabaseURLValue()
         self.assertEqual(value.default, {})
         with env(DATABASE_URL='sqlite://'):
-            self.assertEqual(value.setup('DATABASE_URL'), {
-                'default': {
+            settings_value = value.setup('DATABASE_URL')
+            # Compare the embedded dicts in the "default" entry so that the difference can be seen if 
+            # it fails ... DatabaseURLValue(|) uses an external app that can add additional entries
+            self.assertDictEqual({
                     'CONN_HEALTH_CHECKS': False,
                     'CONN_MAX_AGE': 0,
+                    'DISABLE_SERVER_SIDE_CURSORS': False,
                     'ENGINE': 'django.db.backends.sqlite3',
                     'HOST': '',
                     'NAME': ':memory:',
                     'PASSWORD': '',
                     'PORT': '',
                     'USER': '',
-                }})
+                }, settings_value['default'])
 
     def test_database_url_additional_args(self):
 


### PR DESCRIPTION
Fix failing tet due to change in v2.2.0 (2024-05-28) of dj-database-url which added an extra param DISABLE_SERVER_SIDE_CURSORS

Fix the codecoverage action