### PR TITLE
Remove ENV_LOADED from test class

### DIFF
--- a/tests/settings/main.py
+++ b/tests/settings/main.py
@@ -2,15 +2,12 @@ import os
 import uuid
 
 from configurations import Configuration, pristinemethod
-from configurations.values import BooleanValue
 
 
 class Test(Configuration):
     BASE_DIR = os.path.abspath(
         os.path.join(os.path.dirname(
             os.path.abspath(__file__)), os.pardir))
-
-    ENV_LOADED = BooleanValue(False)
 
     DEBUG = True
 


### PR DESCRIPTION
Unused since the test was refactored to use an alternative `DOTENV_LOADED` attribute: https://github.com/adamchainz/django-configurations/commit/27eb748d68f4593643804c2ff03e6438ea0c091a#diff-fdfcd5f2f4243e852388648dd8f442958a8df44c9d883c568d4380163b4164ecL10