### PR TITLE
Add environ_prefix class decorator (#240)

### DIFF
--- a/configurations/__init__.py
+++ b/configurations/__init__.py
@@ -1,9 +1,9 @@
 from .base import Configuration  # noqa
-from .decorators import pristinemethod  # noqa
+from .decorators import environ_prefix, pristinemethod  # noqa
 from .version import __version__  # noqa
 
 
-__all__ = ['Configuration', 'pristinemethod']
+__all__ = ['Configuration', 'environ_prefix', 'pristinemethod']
 
 
 def _setup():

--- a/configurations/base.py
+++ b/configurations/base.py
@@ -4,7 +4,7 @@ import re
 from django.conf import global_settings
 from django.core.exceptions import ImproperlyConfigured
 
-from .utils import uppercase_attributes
+from .utils import uppercase_attributes, UNSET
 from .values import Value, setup_value
 
 __all__ = ['Configuration']
@@ -99,6 +99,7 @@ class Configuration(metaclass=ConfigurationBase):
 
     """
     DOTENV_LOADED = None
+    _environ_prefix = UNSET
 
     @classmethod
     def load_dotenv(cls):
@@ -154,4 +155,5 @@ class Configuration(metaclass=ConfigurationBase):
     def setup(cls):
         for name, value in uppercase_attributes(cls).items():
             if isinstance(value, Value):
+                value._class_environ_prefix = cls._environ_prefix
                 setup_value(cls, name, value)

--- a/configurations/decorators.py
+++ b/configurations/decorators.py
@@ -1,3 +1,6 @@
+from django.core.exceptions import ImproperlyConfigured
+
+
 def pristinemethod(func):
     """
     A decorator for handling pristine settings like callables.
@@ -17,3 +20,30 @@ def pristinemethod(func):
     """
     func.pristine = True
     return staticmethod(func)
+
+
+def environ_prefix(prefix):
+    """
+    A class Configuration class decorator that prefixes ``prefix``
+    to environment names.
+
+    Use it like this::
+
+        @environ_prefix("MYAPP")
+        class Develop(Configuration):
+            SOMETHING = values.Value()
+
+    To remove the prefix from environment names::
+
+        @environ_prefix(None)
+        class Develop(Configuration):
+            SOMETHING = values.Value()
+
+    """
+    if not isinstance(prefix, (type(None), str)):
+        raise ImproperlyConfigured("environ_prefix accepts only str and None values.")
+
+    def decorator(conf_cls):
+        conf_cls._environ_prefix = prefix
+        return conf_cls
+    return decorator

--- a/configurations/utils.py
+++ b/configurations/utils.py
@@ -99,3 +99,11 @@ def getargspec(func):
     if not inspect.isfunction(func):
         raise TypeError('%r is not a Python function' % func)
     return inspect.getfullargspec(func)
+
+
+class Unset:
+    def __repr__(self):  # pragma: no cover
+        return "UNSET"
+
+
+UNSET = Unset()

--- a/tests/settings/prefix_decorator.py
+++ b/tests/settings/prefix_decorator.py
@@ -1,0 +1,26 @@
+from configurations import Configuration, environ_prefix, values
+
+
+@environ_prefix("ACME")
+class PrefixDecoratorConf1(Configuration):
+    FOO = values.Value()
+
+
+@environ_prefix("ACME")
+class PrefixDecoratorConf2(Configuration):
+    FOO = values.BooleanValue(False)
+
+
+@environ_prefix("ACME")
+class PrefixDecoratorConf3(Configuration):
+    FOO = values.Value(environ_prefix="ZEUS")
+
+
+@environ_prefix("")
+class PrefixDecoratorConf4(Configuration):
+    FOO = values.Value()
+
+
+@environ_prefix(None)
+class PrefixDecoratorConf5(Configuration):
+    FOO = values.Value()

--- a/tests/test_prefix_decorator.py
+++ b/tests/test_prefix_decorator.py
@@ -1,0 +1,57 @@
+import os
+import importlib
+
+from django.core.exceptions import ImproperlyConfigured
+from django.test import TestCase
+from unittest.mock import patch
+
+from configurations import environ_prefix
+from tests.settings import prefix_decorator
+
+
+class EnvironPrefixDecoratorTests(TestCase):
+    @patch.dict(os.environ, clear=True,
+                DJANGO_CONFIGURATION="PrefixDecoratorConf1",
+                DJANGO_SETTINGS_MODULE="tests.settings.prefix_decorator",
+                ACME_FOO="bar")
+    def test_prefix_decorator_with_value(self):
+        importlib.reload(prefix_decorator)
+        self.assertEqual(prefix_decorator.FOO, "bar")
+
+    @patch.dict(os.environ, clear=True,
+                DJANGO_CONFIGURATION="PrefixDecoratorConf2",
+                DJANGO_SETTINGS_MODULE="tests.settings.prefix_decorator",
+                ACME_FOO="True")
+    def test_prefix_decorator_for_value_subclasses(self):
+        importlib.reload(prefix_decorator)
+        self.assertIs(prefix_decorator.FOO, True)
+
+    @patch.dict(os.environ, clear=True,
+                DJANGO_CONFIGURATION="PrefixDecoratorConf3",
+                DJANGO_SETTINGS_MODULE="tests.settings.prefix_decorator",
+                ZEUS_FOO="bar")
+    def test_value_prefix_takes_precedence(self):
+        importlib.reload(prefix_decorator)
+        self.assertEqual(prefix_decorator.FOO, "bar")
+
+    @patch.dict(os.environ, clear=True,
+                DJANGO_CONFIGURATION="PrefixDecoratorConf4",
+                DJANGO_SETTINGS_MODULE="tests.settings.prefix_decorator",
+                FOO="bar")
+    def test_prefix_decorator_empty_string_value(self):
+        importlib.reload(prefix_decorator)
+        self.assertEqual(prefix_decorator.FOO, "bar")
+
+    @patch.dict(os.environ, clear=True,
+                DJANGO_CONFIGURATION="PrefixDecoratorConf5",
+                DJANGO_SETTINGS_MODULE="tests.settings.prefix_decorator",
+                FOO="bar")
+    def test_prefix_decorator_none_value(self):
+        importlib.reload(prefix_decorator)
+        self.assertEqual(prefix_decorator.FOO, "bar")
+
+    def test_prefix_value_must_be_none_or_str(self):
+        class Conf:
+            pass
+
+        self.assertRaises(ImproperlyConfigured, lambda: environ_prefix(1)(Conf))


### PR DESCRIPTION
Adding the `environ_prefix` decorator to configure env names on a per-class basis.

[ticket](https://github.com/jazzband/django-configurations/issues/240)